### PR TITLE
Change flexbox layout to grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
     <!-- HOMEPAGE HERO SECTION -->
     <section>
-        <div class="flex-container homepage-hero">
+        <div class="grid-container homepage-hero nav-margin">
             <div class="sub-container">
                 <h1>plants for<br>mental health</h1>
                 <p>we're on a mission to increase happiness everywhere by raising awareness about the positive effects of plants on mental health</p>
@@ -52,7 +52,7 @@
             <p class="light-text">studies show that</p>
             <h3>all plants provide mental health benefits</h3>
             <p class="light-text">Being arount plants helps us feel more calm and relaxed, thus decreasing levels of anxiety. We can help you find a plant that suits your home and lifestyle, so you can reap the benefits of a greener space.</p>
-            <div class="grid-container">
+            <div class="grid-container button-container">
                 <button class="btn-secondary"><i class="fa-solid fa-sun fa-xl"></i>sun-lovers<p>click here to see plants that thrive in sunny spots</p></button>
                 <button class="btn-secondary"><i class="fa-solid fa-cloud-sun fa-xl"></i>shade-lovers<p>click here to see plants that thrive in shaded spots</p></button>
                 <button class="btn-secondary"><i class="fa-solid fa-droplet fa-xl"></i>humidity-lovers<p>click here to see plants that thrive in high humidity</p></button>
@@ -67,7 +67,7 @@
 
     <!-- HOMEPAGE DID YOU KNOW SECTION -->
     <section>
-        <div class="flex-container">
+        <div class="grid-container homepage-hero">
             <div class="sub-container">
                 <img src="./images/drawkit-eco-illustration-4.png" class="illustration" alt="">
             </div>

--- a/style.css
+++ b/style.css
@@ -29,9 +29,14 @@ body {
     margin-inline: auto;
 }
 
+.grid-container {
+    display: grid;
+    margin-inline: auto;
+}
+
 section {
     width: min(1200px, 90%);
-    margin: 0 auto;
+    margin-inline: auto;
 }
 
 @media only screen and (max-width:740px) {
@@ -112,6 +117,10 @@ a {
     text-decoration-color: var(--lilac);
 }
 
+.nav-margin {
+    margin-top: 80px;
+}
+
 /*===============
 ==WAVE DIVIDERS==
 ===============*/
@@ -185,7 +194,8 @@ button:active {
 ===============*/
 
 .homepage-hero {
-    margin-top: 80px;
+    grid-template: 1fr / 1fr 1fr;
+    width: min(1000px, 100%);
 }
 
 .homepage-hero p {
@@ -194,16 +204,15 @@ button:active {
 }
 
 .sub-container {
+    display: flex;
     justify-content: center;
     align-items: center;
-    width: 50%;
-    display: flex;
     flex-direction: column;
 }
 
 .illustration {
-    width: 80%;
-    align-self: center;
+    width: 90%;
+    filter: drop-shadow(2px 2px 5px rgba(53, 53, 25, 0.3));
 }
 
 .homepage-benefits {
@@ -212,14 +221,28 @@ button:active {
 }
 
 .green-bg {
-    background-color: #bab653;
+    background-color: var(--light-green);
 
 }
 
-.grid-container {
-    margin-inline: auto;
-    display: grid;
+.button-container {
     grid-template: 1fr 1fr / 1fr 1fr;
     grid-gap: 1.5rem;
     margin-top: 50px
+}
+
+@media only screen and (max-width:730px) {
+    .homepage-hero {
+        margin-top: 50px;
+        grid-template: 1fr 1fr / 1fr;
+    }
+    .button-container {
+        grid-template: repeat(4, 1fr) / 1fr;
+    }
+    .illustration {
+        width: 100%;
+    }
+    .homepage-hero p {
+        width: 85%;
+    }
 }


### PR DESCRIPTION
Change layout methods of the two main homepage sections to use grid instead of flexbox. Enables easier switching between desktop and mobile layouts. The more rigid layout provided by CSS grid works better with the content I have on this page.